### PR TITLE
Added a new way to inject parameters into the tenant storage services…

### DIFF
--- a/src/IStorageSettings.cs
+++ b/src/IStorageSettings.cs
@@ -1,0 +1,14 @@
+﻿namespace Talegen.AspNetCore.Multitenant
+{
+    /// <summary>
+    /// This interface defines the minimum implementation of a storage settings class.
+    /// </summary>
+    public interface IStorageSettings
+    {
+        /// <summary>
+        /// Gets or sets the name of the application.
+        /// </summary>
+        /// <value>The name of the application.</value>
+        string ApplicationName { get; set; }
+    }
+}

--- a/src/Stores/MemoryStoreSettings.cs
+++ b/src/Stores/MemoryStoreSettings.cs
@@ -1,0 +1,15 @@
+﻿namespace Talegen.AspNetCore.Multitenant.Stores
+{
+    /// <summary>
+    /// This class implements the storage settings interface for memory storage.
+    /// </summary>
+    /// <seealso cref="Talegen.AspNetCore.Multitenant.IStorageSettings" />
+    public class MemoryStoreSettings : IStorageSettings
+    {
+        /// <summary>
+        /// Gets or sets the name of the application.
+        /// </summary>
+        /// <value>The name of the application.</value>
+        public string ApplicationName { get; set; }
+    }
+}

--- a/src/Stores/RedisStoreSettings.cs
+++ b/src/Stores/RedisStoreSettings.cs
@@ -1,0 +1,15 @@
+﻿namespace Talegen.AspNetCore.Multitenant.Stores
+{
+    /// <summary>
+    /// This class implements the storage settings interface for Redis storage.
+    /// </summary>
+    /// <seealso cref="Talegen.AspNetCore.Multitenant.IStorageSettings" />
+    public class RedisStoreSettings : IStorageSettings
+    {
+        /// <summary>
+        /// Gets or sets the name of the application.
+        /// </summary>
+        /// <value>The name of the application.</value>
+        public string ApplicationName { get; set; }
+    }
+}

--- a/src/Stores/TenantMemoryStore.cs
+++ b/src/Stores/TenantMemoryStore.cs
@@ -50,10 +50,11 @@ namespace Talegen.AspNetCore.Multitenant.Stores
         /// Initializes a new instance of the <see cref="TenantMemoryStore{TTenant}" /> class.
         /// </summary>
         /// <param name="cache">Contains an instance of the <see cref="IMemoryCache" /> cache object.</param>
-        public TenantMemoryStore(IMemoryCache cache)
+        /// <param name="settings">Contains an optional storage settings object.</param>
+        public TenantMemoryStore(IMemoryCache cache, IStorageSettings settings = null)
         {
             this.cache = cache;
-            this.applicationName = Resources.ApplicationName;
+            this.applicationName = settings != null && !string.IsNullOrWhiteSpace(settings.ApplicationName) ? settings.ApplicationName : Resources.ApplicationName;
         }
 
         /// <summary>

--- a/src/Stores/TenantRedisStore.cs
+++ b/src/Stores/TenantRedisStore.cs
@@ -51,10 +51,11 @@ namespace Talegen.AspNetCore.Multitenant.Stores
         /// Initializes a new instance of the <see cref="TenantRedisStore{TTenant}" /> class.
         /// </summary>
         /// <param name="cache">The cache.</param>
-        public TenantRedisStore(IAdvancedDistributedCache cache)
+        /// <param name="settings">Contains an optional storage settings object.</param>
+        public TenantRedisStore(IAdvancedDistributedCache cache, IStorageSettings settings = null)
         {
             this.cache = cache;
-            this.applicationName = Resources.ApplicationName;
+            this.applicationName = settings != null && !string.IsNullOrWhiteSpace(settings.ApplicationName) ? settings.ApplicationName : Resources.ApplicationName;
         }
 
         /// <summary>

--- a/src/Talegen.AspNetCore.Multitenant.csproj
+++ b/src/Talegen.AspNetCore.Multitenant.csproj
@@ -11,8 +11,8 @@
     <RepositoryUrl>https://github.com/Talegen/Talegen.AspNetCore.Multitenant</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Tenant</PackageTags>
-    <PackageReleaseNotes>Fixed bug key string formatting for Redis store</PackageReleaseNotes>
-    <Version>1.0.6.0</Version>
+    <PackageReleaseNotes>Added a new way to inject parameters into the tenant storage services via DI. Allowing the developer to change the application name used in cache key naming.</PackageReleaseNotes>
+    <Version>1.0.7.0</Version>
     <NeutralLanguage>en</NeutralLanguage>
     <ApplicationIcon>assets\logo.ico</ApplicationIcon>
     <PackageIcon>logo.png</PackageIcon>

--- a/src/Talegen.AspNetCore.Multitenant.xml
+++ b/src/Talegen.AspNetCore.Multitenant.xml
@@ -24,6 +24,17 @@
             </summary>
             <seealso cref="T:Talegen.Backchannel.BackchannelConfig" />
         </member>
+        <member name="T:Talegen.AspNetCore.Multitenant.IStorageSettings">
+            <summary>
+            This interface defines the minimum implementation of a storage settings class.
+            </summary>
+        </member>
+        <member name="P:Talegen.AspNetCore.Multitenant.IStorageSettings.ApplicationName">
+            <summary>
+            Gets or sets the name of the application.
+            </summary>
+            <value>The name of the application.</value>
+        </member>
         <member name="T:Talegen.AspNetCore.Multitenant.ITenant">
             <summary>
             This interface represents the minimum implementation of a tenant information model.
@@ -343,6 +354,30 @@
             <param name="cancellationToken">Contains an optional cancellation token.</param>
             <returns>Returns the <see cref="T:Talegen.AspNetCore.Multitenant.ITenant" /> object if found.</returns>
         </member>
+        <member name="T:Talegen.AspNetCore.Multitenant.Stores.MemoryStoreSettings">
+            <summary>
+            This class implements the storage settings interface for memory storage.
+            </summary>
+            <seealso cref="T:Talegen.AspNetCore.Multitenant.IStorageSettings" />
+        </member>
+        <member name="P:Talegen.AspNetCore.Multitenant.Stores.MemoryStoreSettings.ApplicationName">
+            <summary>
+            Gets or sets the name of the application.
+            </summary>
+            <value>The name of the application.</value>
+        </member>
+        <member name="T:Talegen.AspNetCore.Multitenant.Stores.RedisStoreSettings">
+            <summary>
+            This class implements the storage settings interface for Redis storage.
+            </summary>
+            <seealso cref="T:Talegen.AspNetCore.Multitenant.IStorageSettings" />
+        </member>
+        <member name="P:Talegen.AspNetCore.Multitenant.Stores.RedisStoreSettings.ApplicationName">
+            <summary>
+            Gets or sets the name of the application.
+            </summary>
+            <value>The name of the application.</value>
+        </member>
         <member name="T:Talegen.AspNetCore.Multitenant.Stores.TenantMemoryStore`1">
             <summary>
             Implements a tenant store utilizing <see cref="T:Microsoft.Extensions.Caching.Memory.IMemoryCache" /> storage.
@@ -365,11 +400,12 @@
             Contains the application name.
             </summary>
         </member>
-        <member name="M:Talegen.AspNetCore.Multitenant.Stores.TenantMemoryStore`1.#ctor(Microsoft.Extensions.Caching.Memory.IMemoryCache)">
+        <member name="M:Talegen.AspNetCore.Multitenant.Stores.TenantMemoryStore`1.#ctor(Microsoft.Extensions.Caching.Memory.IMemoryCache,Talegen.AspNetCore.Multitenant.IStorageSettings)">
             <summary>
             Initializes a new instance of the <see cref="T:Talegen.AspNetCore.Multitenant.Stores.TenantMemoryStore`1" /> class.
             </summary>
             <param name="cache">Contains an instance of the <see cref="T:Microsoft.Extensions.Caching.Memory.IMemoryCache" /> cache object.</param>
+            <param name="settings">Contains an optional storage settings object.</param>
         </member>
         <member name="M:Talegen.AspNetCore.Multitenant.Stores.TenantMemoryStore`1.AllTenantsAsync(System.Threading.CancellationToken)">
             <summary>
@@ -419,11 +455,12 @@
             Contains the application name.
             </summary>
         </member>
-        <member name="M:Talegen.AspNetCore.Multitenant.Stores.TenantRedisStore`1.#ctor(Vasont.AspnetCore.RedisClient.IAdvancedDistributedCache)">
+        <member name="M:Talegen.AspNetCore.Multitenant.Stores.TenantRedisStore`1.#ctor(Vasont.AspnetCore.RedisClient.IAdvancedDistributedCache,Talegen.AspNetCore.Multitenant.IStorageSettings)">
             <summary>
             Initializes a new instance of the <see cref="T:Talegen.AspNetCore.Multitenant.Stores.TenantRedisStore`1" /> class.
             </summary>
             <param name="cache">The cache.</param>
+            <param name="settings">Contains an optional storage settings object.</param>
         </member>
         <member name="M:Talegen.AspNetCore.Multitenant.Stores.TenantRedisStore`1.AllTenantsAsync(System.Threading.CancellationToken)">
             <summary>
@@ -516,11 +553,21 @@
             <param name="lifetime">The lifetime.</param>
             <returns>Returns the tenant builder.</returns>
         </member>
-        <member name="M:Talegen.AspNetCore.Multitenant.TenantBuilder`1.WithStore``1(Microsoft.Extensions.DependencyInjection.ServiceLifetime)">
+        <member name="M:Talegen.AspNetCore.Multitenant.TenantBuilder`1.WithStorageSettings``1(``0,Microsoft.Extensions.DependencyInjection.ServiceLifetime)">
+            <summary>
+            Implements the specific tenant storage settings for a given type.
+            </summary>
+            <typeparam name="TStorageType">The type of the storage type to implement.</typeparam>
+            <param name="settings">The settings.</param>
+            <param name="lifetime">The lifetime.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Talegen.AspNetCore.Multitenant.TenantBuilder`1.WithStore``1(Talegen.AspNetCore.Multitenant.IStorageSettings,Microsoft.Extensions.DependencyInjection.ServiceLifetime)">
             <summary>
             Implements the specific tenant store store method.
             </summary>
             <typeparam name="TStore">The type of the store.</typeparam>
+            <param name="storageSettings">Contains an optional storage settings.</param>
             <param name="lifetime">The lifetime.</param>
             <returns>Returns the tenant builder.</returns>
         </member>

--- a/src/TenantBuilder.cs
+++ b/src/TenantBuilder.cs
@@ -51,13 +51,33 @@ namespace Talegen.AspNetCore.Multitenant
         }
 
         /// <summary>
+        /// Implements the specific tenant storage settings for a given type.
+        /// </summary>
+        /// <typeparam name="TStorageType">The type of the storage type to implement.</typeparam>
+        /// <param name="settings">The settings.</param>
+        /// <param name="lifetime">The lifetime.</param>
+        /// <returns>Returns the tenant builder.</returns>
+        public TenantBuilder<TTenant> WithStorageSettings<TStorageType>(TStorageType settings, ServiceLifetime lifetime = ServiceLifetime.Singleton)
+        {
+            this.services.Add(ServiceDescriptor.Describe(typeof(TStorageType), (provider) => { return settings; }, lifetime));
+            return this;
+        }
+
+        /// <summary>
         /// Implements the specific tenant store store method.
         /// </summary>
         /// <typeparam name="TStore">The type of the store.</typeparam>
+        /// <param name="storageSettings">Contains an optional storage settings.</param>
         /// <param name="lifetime">The lifetime.</param>
         /// <returns>Returns the tenant builder.</returns>
-        public TenantBuilder<TTenant> WithStore<TStore>(ServiceLifetime lifetime = ServiceLifetime.Transient) where TStore : class, ITenantStore<TTenant>
+        public TenantBuilder<TTenant> WithStore<TStore>(IStorageSettings storageSettings = null, ServiceLifetime lifetime = ServiceLifetime.Transient) where TStore : class, ITenantStore<TTenant>
         {
+            // if storage settings are declared, use them here.
+            if (storageSettings != null)
+            {
+                this.services.AddSingleton(storageSettings);
+            }
+
             this.services.Add(ServiceDescriptor.Describe(typeof(ITenantStore<TTenant>), typeof(TStore), lifetime));
             return this;
         }


### PR DESCRIPTION
… via DI. Allowing the developer to change the application name used in cache key naming.